### PR TITLE
Task change assignee

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,74 @@
+import pytest
+from users.models import User, Team, Role
+from tasks.models import Task, Priority, Status
+from falcon.test_support import Random
+
+
+@pytest.fixture
+def teams():
+    """
+    Adds teams to DB
+    """
+    team1 = Team.objects.create(name="Team1",
+                                description="This is a test team")
+    team2 = Team.objects.create(name="Team2",
+                                description="This is a test team")
+    team3 = Team.objects.create(name="Team3",
+                                description="This is a test team")
+    return team1, team2, team3
+
+
+@pytest.fixture
+def users(teams):
+    """
+    Adds users to DB
+    """
+    team1, team2, team3 = teams
+    employees = []
+    managers = []
+    users_counter = 0
+    for i in range(3):
+        for team in (team1, team2):
+            print()
+            employee = User.create_user(f"User{users_counter}", Random.email(), "ssSSAD231!@",
+                                        Random.string(5), Random.string(5), Role.EMPLOYEE, team)
+            employees += [employee]
+            users_counter += 1
+    for i, team in enumerate((team1, team2, team3)):
+        manager = User.create_user(f"Manager{i}", Random.email(), "ssSSAD231!@",
+                                   Random.string(5), Random.string(5), Role.MANAGER, team)
+        managers += [manager]
+    return teams, tuple(employees), tuple(managers)
+
+
+@pytest.fixture
+def tasks(users):
+    """
+    Adds tasks to DB
+    """
+    teams, employees, managers = users
+    tasks = []
+    for k in range(3):
+        for i in range(3):
+            for j in range(2):
+                task = Task.objects.create(title=f"Task{j}",
+                                           assignee=employees[k + i],
+                                           created_by=managers[k],
+                                           priority=Priority.LOW,
+                                           status=Status.BACKLOG,
+                                           description="Test task")
+                tasks += [task]
+        return teams, employees, managers, tuple(tasks)
+
+
+@pytest.fixture
+def test_db(tasks):
+    """
+    Returns test DB components as tuples.
+    The test DB contains: 3 teams, 3 users per team, 2 tasks per user, 1 manager per team.
+    """
+    teams = tasks[0]
+    employees = tasks[1]
+    managers = tasks[2]
+    task = tasks[3]
+    return teams, employees, managers, task

--- a/conftest.py
+++ b/conftest.py
@@ -8,13 +8,10 @@ def teams():
     """
     Adds teams to DB
     """
-    team1 = Team.objects.create(name="Team1",
-                                description="This is a test team")
-    team2 = Team.objects.create(name="Team2",
-                                description="This is a test team")
-    team3 = Team.objects.create(name="Team3",
-                                description="This is a test team")
-    return team1, team2, team3
+
+    return tuple(Team.objects.create(name=f"Team{i}",
+                                     description="This is a test team")
+                 for i in range(3))
 
 
 @pytest.fixture
@@ -35,7 +32,7 @@ def users(teams):
                                         last_name=f"User{users_counter}",
                                         role=Role.EMPLOYEE,
                                         team=team)
-            employees += [employee]
+            employees.append(employee)
             users_counter += 1
     for i, team in enumerate((team1, team2, team3)):
         manager = User.create_user(username=f"Manager{i}",
@@ -65,7 +62,7 @@ def tasks(users):
                                            priority=Priority.LOW,
                                            status=Status.BACKLOG,
                                            description="Test task")
-                tasks += [task]
+                tasks.append(task)
         return teams, employees, managers, tuple(tasks)
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,7 +1,6 @@
 import pytest
 from users.models import User, Team, Role
 from tasks.models import Task, Priority, Status
-from falcon.test_support import Random
 
 
 @pytest.fixture
@@ -29,14 +28,23 @@ def users(teams):
     users_counter = 0
     for i in range(3):
         for team in (team1, team2):
-            print()
-            employee = User.create_user(f"User{users_counter}", Random.email(), "ssSSAD231!@",
-                                        Random.string(5), Random.string(5), Role.EMPLOYEE, team)
+            employee = User.create_user(username=f"User{users_counter}",
+                                        email=f"User{users_counter}@redhat.com",
+                                        password="ssSSAD231!@",
+                                        first_name=f"User{users_counter}",
+                                        last_name=f"User{users_counter}",
+                                        role=Role.EMPLOYEE,
+                                        team=team)
             employees += [employee]
             users_counter += 1
     for i, team in enumerate((team1, team2, team3)):
-        manager = User.create_user(f"Manager{i}", Random.email(), "ssSSAD231!@",
-                                   Random.string(5), Random.string(5), Role.MANAGER, team)
+        manager = User.create_user(username=f"Manager{i}",
+                                   email=f"Manager{i}@redhat.com",
+                                   password="ssSSAD231!@",
+                                   first_name=f"Manager{i}",
+                                   last_name=f"Manager{i}",
+                                   role=Role.MANAGER,
+                                   team=team)
         managers += [manager]
     return teams, tuple(employees), tuple(managers)
 

--- a/tasks/models.py
+++ b/tasks/models.py
@@ -54,6 +54,11 @@ class Task(models.Model):
         return cls.objects.filter(priority=priority_filter)
 
     def change_assignee(self, new_assignee):
+        prev_assignee = self.assignee
+        if new_assignee is None:
+            raise TypeError("Valid user must be provided")
+        if new_assignee.team != prev_assignee.team:
+            raise ValueError("The new assignee must be of the same team")
         self.assignee = new_assignee
 
 

--- a/tasks/models.py
+++ b/tasks/models.py
@@ -53,6 +53,9 @@ class Task(models.Model):
         print(priority_filter)
         return cls.objects.filter(priority=priority_filter)
 
+    def change_assignee(self, new_assignee):
+        self.assignee = new_assignee
+
 
 class Comment(models.Model):
     appUser = models.ForeignKey(

--- a/tasks/models.py
+++ b/tasks/models.py
@@ -54,6 +54,8 @@ class Task(models.Model):
         return cls.objects.filter(priority=priority_filter)
 
     def change_assignee(self, new_assignee):
+        if new_assignee not in User.objects.all():
+            raise Exception
         prev_assignee = self.assignee
         if new_assignee is None:
             raise TypeError("Valid user must be provided")

--- a/tasks/tests/test_change_assignee.py
+++ b/tasks/tests/test_change_assignee.py
@@ -1,12 +1,37 @@
 import pytest
 from tasks.models import Task
+from users.models import Team, User
 
 
 @pytest.mark.django_db
 class TestChangeTaskAssignee:
     def test_change_task_assignee(self, test_db):
-        _, employees, _, _ = test_db
-        task = Task.objects.filter(assignee=employees[0]).first()
+        team = test_db[0][0]
+        employee_1, employee_2 = User.objects.filter(team=team)[:2]
+        task = Task.objects.filter(assignee=employee_1).first()
         assert task is not None
-        task.change_assignee(employees[1])
-        assert task.assignee == employees[1]
+        assert task.assignee == employee_1
+        task.change_assignee(employee_2)
+        assert task.assignee == employee_2
+    
+    @pytest.mark.parametrize("invalid_input", ["INVALID VALUE", None, 2])
+    def test_change_assignee_invalid_input(self, test_db, invalid_input):
+        _, _, _, tasks = test_db
+        task = tasks[0]
+        assignee = task.assignee
+        with pytest.raises(Exception):
+            task.change_assignee(invalid_input)
+        assert assignee == task.assignee
+
+    def test_change_assignee_other_team(self, test_db):
+        teams = Team.objects.all()
+        assert len(teams) > 0
+        team_1 = teams[0]
+        team_2 = teams[1]
+        employee_1 = User.objects.filter(team=team_1).first()
+        employee_2 = User.objects.filter(team=team_2).first()
+        task = Task.objects.filter(assignee=employee_1).first()
+        with pytest.raises(Exception):
+            task.change_assignee(employee_2)
+        assert task.assignee == employee_1
+

--- a/tasks/tests/test_change_assignee.py
+++ b/tasks/tests/test_change_assignee.py
@@ -13,7 +13,7 @@ class TestChangeTaskAssignee:
         assert task.assignee == employee_1
         task.change_assignee(employee_2)
         assert task.assignee == employee_2
-    
+
     @pytest.mark.parametrize("invalid_input", ["INVALID VALUE", None, 2])
     def test_change_assignee_invalid_input(self, test_db, invalid_input):
         _, _, _, tasks = test_db
@@ -34,4 +34,3 @@ class TestChangeTaskAssignee:
         with pytest.raises(Exception):
             task.change_assignee(employee_2)
         assert task.assignee == employee_1
-

--- a/tasks/tests/test_change_assignee.py
+++ b/tasks/tests/test_change_assignee.py
@@ -1,6 +1,7 @@
 import pytest
 from tasks.models import Task
-from users.models import Team, User
+from users.models import Team, User, Role
+from django.contrib.auth.models import User as DjangoUser
 
 
 @pytest.mark.django_db
@@ -34,3 +35,20 @@ class TestChangeTaskAssignee:
         with pytest.raises(Exception):
             task.change_assignee(employee_2)
         assert task.assignee == employee_1
+
+    @pytest.fixture
+    def out_db_user(self, test_db):
+        team = test_db[0][0]
+        django_user = DjangoUser.objects.create(username="testtest",
+                                                password="ssdalhSFDAJ23!",
+                                                email="example@redhat.com",
+                                                first_name="test",
+                                                last_name="test")
+        user = User(user=django_user, role=Role.EMPLOYEE, team=team)
+        return user
+
+    def test_change_assignee_not_db_user(self, test_db, out_db_user):
+        tasks = test_db[3]
+        task = tasks[0]
+        with pytest.raises(Exception):
+            task.change_assignee(out_db_user)

--- a/tasks/tests/test_change_assignee.py
+++ b/tasks/tests/test_change_assignee.py
@@ -26,7 +26,7 @@ class TestChangeTaskAssignee:
 
     def test_change_assignee_other_team(self, test_db):
         teams = Team.objects.all()
-        assert len(teams) > 0
+        assert len(teams) >= 2
         team_1 = teams[0]
         team_2 = teams[1]
         employee_1 = User.objects.filter(team=team_1).first()
@@ -48,7 +48,6 @@ class TestChangeTaskAssignee:
         return user
 
     def test_change_assignee_not_db_user(self, test_db, out_db_user):
-        tasks = test_db[3]
-        task = tasks[0]
+        task = test_db[3][0]
         with pytest.raises(Exception):
             task.change_assignee(out_db_user)

--- a/tasks/tests/test_change_assignee.py
+++ b/tasks/tests/test_change_assignee.py
@@ -1,0 +1,12 @@
+import pytest
+from tasks.models import Task
+
+
+@pytest.mark.django_db
+class TestChangeTaskAssignee:
+    def test_change_task_assignee(self, test_db):
+        _, employees, _, _ = test_db
+        task = Task.objects.filter(assignee=employees[0]).first()
+        assert task is not None
+        task.change_assignee(employees[1])
+        assert task.assignee == employees[1]

--- a/tasks/tests/test_tasks_filters.py
+++ b/tasks/tests/test_tasks_filters.py
@@ -1,4 +1,3 @@
-from django.contrib.auth.models import User as DjangoUser
 from django.db.models.query import QuerySet
 import pytest
 from tasks.models import Priority, Task, Status
@@ -14,15 +13,13 @@ class DBPrepare:
     @staticmethod
     def create_example_employee(username):
         team = Team.objects.first()
-        django_user = DjangoUser.objects.create_user(username=username,
-                                                     email="example@gmail.com",
-                                                     password='xsdDS23',
-                                                     first_name="Test",
-                                                     last_name="Test")
-        employee = User.objects.create(user=django_user,
-                                       role=Role.EMPLOYEE,
-                                       team_id=team)
-        employee.save()
+        employee = User.create_user(username=username,
+                                    email="example@gmail.com",
+                                    password='xsdDS23',
+                                    first_name="Test",
+                                    last_name="Test",
+                                    role=Role.EMPLOYEE,
+                                    team=team)
         return employee
 
     """
@@ -31,15 +28,13 @@ class DBPrepare:
     @staticmethod
     def create_example_manager(username):
         team = Team.objects.first()
-        django_user = DjangoUser.objects.create_user(username=username,
-                                                     email="example@gmail.com",
-                                                     password='xsdDS23',
-                                                     first_name="Test",
-                                                     last_name="Test")
-        manager = User.objects.create(user=django_user,
-                                      role=Role.MANAGER,
-                                      team_id=team)
-        manager.save()
+        manager = User.create_user(username=username,
+                                   email="example@gmail.com",
+                                   password='xsdDS23',
+                                   first_name="Test",
+                                   last_name="Test",
+                                   role=Role.MANAGER,
+                                   team=team)
         return manager
 
     """
@@ -48,7 +43,6 @@ class DBPrepare:
     @staticmethod
     def create_example_team():
         team = Team.objects.create(name="TestTeam", description="Test Team")
-        team.save()
         return team
 
     """
@@ -65,7 +59,6 @@ class DBPrepare:
                                     status=status,
                                     priority=priority,
                                     description=description)
-        task.save()
         return task
 
 


### PR DESCRIPTION
Fixes #77 
This PR adds the ability to change the assigned employee of a given task in DB.

## Changes you made

**- Create conftest.py for reusable fixtures** 
Added fixtures that create a test DB we can use in future tests (and refactor previous tests to prevent code duplications that we already have).
**- Add change_assignee function to Task model**
This function is a Task instance's function that changes the assigned employee for the given task.
**- Add change_assignee tests**
Tests for change_assignee tests.


