### PR TITLE
Add all tasks template

### DIFF
--- a/falcon/urls.py
+++ b/falcon/urls.py
@@ -22,5 +22,6 @@ from . import views
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('', views.homepage, name='homepage'),
-    path('', include('users.urls'))
+    path('', include('users.urls')),
+    path('', include('tasks.urls')),
 ]

--- a/tasks/models.py
+++ b/tasks/models.py
@@ -55,7 +55,7 @@ class Task(models.Model):
     @classmethod
     def filter_by_team(cls, team_filter):
         if not isinstance(team_filter, Team):
-            raise ValueError("A valid team must be provided")
+            raise TypeError("A valid team must be provided")
         return cls.objects.filter(assignee__team=team_filter)
 
     def change_assignee(self, new_assignee):

--- a/tasks/models.py
+++ b/tasks/models.py
@@ -1,6 +1,6 @@
 from django.db import models, transaction
 from enumchoicefield import ChoiceEnum, EnumChoiceField
-from users.models import Role, User
+from users.models import Role, Team, User
 
 
 class Status(ChoiceEnum):
@@ -50,8 +50,13 @@ class Task(models.Model):
     def filter_by_symbol(cls, priority_filter):
         if not isinstance(priority_filter, Priority):
             raise ValueError
-        print(priority_filter)
         return cls.objects.filter(priority=priority_filter)
+
+    @classmethod
+    def filter_by_team(cls, team_filter):
+        if not isinstance(team_filter, Team):
+            raise ValueError("A valid team must be provided")
+        return cls.objects.filter(assignee__team=team_filter)
 
     def change_assignee(self, new_assignee):
         if new_assignee not in User.objects.all():

--- a/tasks/templates/tasks/tasks.html
+++ b/tasks/templates/tasks/tasks.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+{% block content %}
+    {% if user.user.is_authenticated %}
+        <h2>Tasks</h2>
+            {% for task in tasks %}
+            <article class="media content-section">
+                <div class="media_body">
+                    <div class="article_metadata">
+                        <small class="text-muted">
+                            Created on: {{ task.created_date|date:"F d, Y" }} <b>|</b>
+                            Created by: {{ task.created_by|truncatechars:20 }} <b>|</b>
+                            Assignee: {{ task.assignee|truncatechars:20 }}
+                            {% if user.is_staff %}
+                            <b>|</b> {{ task.assignee.team|truncatechars:20 }} 
+                            {% endif %}
+                        </small>
+                    </div>
+                    <h3><a class="article_title" href="#">{{ task.title|truncatechars:35 }}</a></h3>
+                    <p class="article-content">{{ task.description|truncatechars:100 }}</p>
+                </article>
+            {% endfor %}
+    {% else %}
+        This page is restricted. Are you an existing user? Login.
+    {% endif %}
+{% endblock content %}

--- a/tasks/tests/test_tasks_filters.py
+++ b/tasks/tests/test_tasks_filters.py
@@ -137,8 +137,8 @@ class TestTasksFilters:
     """
     def test_team_filter(self, test_db):
         team = test_db[0][0]
-        filtered_tasks = Task.filter_by_team(team)
         assert isinstance(team, Team)
+        filtered_tasks = Task.filter_by_team(team)
         assert isinstance(filtered_tasks, QuerySet)
         assert len(filtered_tasks) > 0
         assert all(isinstance(task, Task) for task in filtered_tasks)

--- a/tasks/tests/test_tasks_filters.py
+++ b/tasks/tests/test_tasks_filters.py
@@ -131,3 +131,23 @@ class TestTasksFilters:
     def test_invalid_status_filter(self, prepare_database):
         with pytest.raises(ValueError):
             Task.filter_by_status('INVALID')
+
+    """
+    Test filtering by team
+    """
+    def test_team_filter(self, test_db):
+        team = test_db[0][0]
+        filtered_tasks = Task.filter_by_team(team)
+        assert isinstance(team, Team)
+        assert isinstance(filtered_tasks, QuerySet)
+        assert len(filtered_tasks) > 0
+        assert all(isinstance(task, Task) for task in filtered_tasks)
+        assert all(task.assignee.team == team for task in filtered_tasks)
+
+    """
+    Test that it is impossible to filter using invalid value
+    """
+    @pytest.mark.parametrize("invalid_input", ["INVALID VALUE", None, 2])
+    def test_invalid_team_filter(self, invalid_input):
+        with pytest.raises(Exception):
+            Team.filter_by_team(invalid_input)

--- a/tasks/tests/test_view_all_tasks.py
+++ b/tasks/tests/test_view_all_tasks.py
@@ -1,0 +1,34 @@
+from conftest import DEFAULT_VALID_PASSWORD
+import pytest
+from tasks.models import Task
+from users.models import User
+
+
+@pytest.mark.django_db
+class TestAllTasksView():
+    def test_not_authenticated_user_access_restricted(self, client, test_db):
+        response = client.get('/tasks/')
+        assert response.status_code == 200
+        assert 'tasks' not in response.context.keys()
+
+    @pytest.mark.parametrize('employee_flag', [(True), (False)],
+                             ids=[
+                                "employee",
+                                "manager"
+                             ])
+    def test_authenticated_user_tasks_view(self, client, test_db, employee_flag):
+        users = test_db[1] if employee_flag else test_db[2]
+        assert len(users) > 0
+        user = users[0]
+        assert isinstance(user, User)
+        client.login(username=user.user.username,
+                     password=DEFAULT_VALID_PASSWORD)
+        response = client.get('/tasks/', enforce_csrf_checks=True)
+        assert response.status_code == 200
+        assert 'tasks' in response.context.keys()
+        assert all(isinstance(task, Task) for task in response.context['tasks'])
+        assert len(response.context['tasks']) > 0
+        if employee_flag:
+            assert all(task.assignee == user for task in response.context['tasks'])
+        else:
+            assert all(task.assignee.team == user.team for task in response.context['tasks'])

--- a/tasks/urls.py
+++ b/tasks/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from tasks import views
+
+urlpatterns = [
+    path('tasks/', views.view_tasks, name='tasks'),
+]

--- a/tasks/views.py
+++ b/tasks/views.py
@@ -7,7 +7,8 @@ def view_tasks(request):
     context = {}
     if not request.user.is_anonymous:
         app_user = User.objects.get(user=request.user)
-        context['tasks'] = Task.filter_by_assignee(request.user.id) if app_user.role == Role.EMPLOYEE \
-            else Task.filter_by_team(app_user.team)
+        context['tasks'] = Task.filter_by_assignee(request.user.id) if app_user.role == Role.EMPLOYEE else (
+            Task.filter_by_team(app_user.team)
+        )
         context['user'] = app_user
     return render(request, 'tasks/tasks.html', context)

--- a/tasks/views.py
+++ b/tasks/views.py
@@ -1,3 +1,13 @@
-# from django.shortcuts import render
+from django.shortcuts import render
+from tasks.models import Task
+from users.models import Role, User
 
-# Create your views here.
+
+def view_tasks(request):
+    context = {}
+    if not request.user.is_anonymous:
+        app_user = User.objects.get(user=request.user)
+        context['tasks'] = Task.filter_by_assignee(request.user.id) if app_user.role == Role.EMPLOYEE \
+            else Task.filter_by_team(app_user.team)
+        context['user'] = app_user
+    return render(request, 'tasks/tasks.html', context)

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -19,6 +19,7 @@
       <!-- Navbar Right Side -->
       <div class="navbar-nav">
         {% if user.user.is_authenticated %}
+          <a class="nav-item nav-link" href="{% url 'tasks' %}">View Tasks</a>
             {% if user.is_manager %}
                 <a class="nav-item nav-link" href="#">New Task</a>
             {% endif %}


### PR DESCRIPTION
Fixes #94
Fixes #93 

This PR adds a new template that displays all the relevant tasks for the logged-in user.
If the logged-in user is an employee, only tasks that were assigned to the given user will be displayed.
If the logged-in user is a manager, tasks that were assigned to a user in the manager's team will be assigned.
This is page is restricted for users who aren't logged inß.

## Changes you made

- Add a new class method to the Team model: filter_by_team.
With this method, it is possible to fetch the relevant tasks for a given team.
- Add tests for the above function.
- Add a new page that displays the tasks.
- Add a new view method that renders the above page.
- Add a new button to the navbar that redirects to the above page.

