### PR TITLE
Refactor PR #105

### DIFF
--- a/users/migrations/0001_initial.py
+++ b/users/migrations/0001_initial.py
@@ -17,8 +17,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.BigAutoField(auto_created=True,
                  primary_key=True, serialize=False, verbose_name='ID')),
-                ('name', models.CharField(max_length=255,
-                 blank=False, default=None, unique=True)),
+                ('name', models.CharField(max_length=255, blank=False, unique=True)),
                 ('description', models.CharField(max_length=500)),
             ],
         ),

--- a/users/models.py
+++ b/users/models.py
@@ -12,7 +12,7 @@ class Role(ChoiceEnum):
 
 # Create your models here.
 class Team(models.Model):
-    name = models.CharField(max_length=255, blank=False, default=None, unique=True)
+    name = models.CharField(max_length=255, blank=False, unique=True)
     description = models.CharField(max_length=500)
 
     def __str__(self) -> str:

--- a/users/tests/test_create_teams.py
+++ b/users/tests/test_create_teams.py
@@ -12,4 +12,13 @@ class TestTeams:
 
     def test_create_team_without_title(self):
         with pytest.raises(Exception):
-            Team.objects.create(description="Best team ever")
+            Team.objects.create(title="", description="Best team ever")
+
+    @pytest.mark.django_db(transaction=True)
+    def test_create_team_with_same_name(self):
+        assert len(Team.objects.all()) == 0
+        Team.objects.create(name="Team1", description="This team will be created")
+        assert len(Team.objects.all()) == 1
+        with pytest.raises(Exception):
+            Team.objects.create(name="Team1", description="This team will be created")
+        assert len(Team.objects.all()) == 1, "Team1 was created twice"


### PR DESCRIPTION
This PR should resolve some refactoring requested on PR #105.
The detailed refactoring request can be found here #105 (Kobi's CR, at the bottom) 

## Changes you made

- Remove 'default=None' from name field on Team model.
- Remove 'default=None' in name field from Team model migration file.
- Add transaction=True to be able to use database operation after an exception catch.
- Change test_create_team_without_title by giving the creating method a blank title (which we expect to raise an exception).