### PR TITLE
Display task comments

### DIFF
--- a/tasks/models.py
+++ b/tasks/models.py
@@ -68,6 +68,9 @@ class Task(models.Model):
             raise ValueError("The new assignee must be of the same team")
         self.assignee = new_assignee
 
+    def get_comments(self):
+        return Comment.objects.filter(task=self).order_by('id')
+
     @classmethod
     @transaction.atomic
     def create_task(cls, title, assignee, created_by, priority, status, description):

--- a/tasks/templates/tasks/view_single_task.html
+++ b/tasks/templates/tasks/view_single_task.html
@@ -34,7 +34,7 @@
   <article class="media content-section">
     <div class="media_body">
       <div class="article_metadata">
-          <b>{{ comment.appUser|truncatechars:20 }}</b>
+          <b>{{ comment.appUser.user.first_name|truncatechars:20 }} {{ comment.appUser.user.last_name|truncatechars:20 }}</b>
           <small class="text-muted">
               {{ comment.created_date|date:"F d, Y" }}
           </small>

--- a/tasks/templates/tasks/view_single_task.html
+++ b/tasks/templates/tasks/view_single_task.html
@@ -31,9 +31,9 @@
     <article class="media content-section">
       <div class="media_body">
         <div class="article_metadata">
-            <b>Assignee: {{ comment.appUser|truncatechars:20 }}</b>
+            <b>{{ comment.appUser|truncatechars:20 }}</b>
             <small class="text-muted">
-                Created on: {{ comment.created_date|date:"F d, Y" }}
+                {{ comment.created_date|date:"F d, Y" }}
             </small>
         </div>
         <p class="article-content">{{ comment.description|truncatechars:400 }}</p>

--- a/tasks/templates/tasks/view_single_task.html
+++ b/tasks/templates/tasks/view_single_task.html
@@ -16,4 +16,18 @@
     </form>
   </div>
 </div>
+<h3>Comments</h3>
+{% for comment in task.get_comments %}
+  <article class="media content-section">
+    <div class="media_body">
+      <div class="article_metadata">
+          <b>Assignee: {{ comment.appUser|truncatechars:20 }}</b>
+          <small class="text-muted">
+              Created on: {{ comment.created_date|date:"F d, Y" }}
+          </small>
+      </div>
+      <p class="article-content">{{ comment.description|truncatechars:400 }}</p>
+    </div>
+  </article>
+{% endfor %}
 {% endblock content %}

--- a/tasks/tests/test_get_task_comments.py
+++ b/tasks/tests/test_get_task_comments.py
@@ -1,0 +1,54 @@
+from django.db.models.query import QuerySet
+import pytest
+from tasks.models import Comment, Priority, Status, Task
+from users.models import Role, User
+
+NUM_COMMENTS = 3
+
+@pytest.mark.django_db
+class TestTaskComments:
+    @pytest.fixture
+    def user_and_manager(self, users):
+        user = users[1][0]
+        manager = users[2][0]
+        assert isinstance(user, User)
+        assert isinstance(user, User)
+        assert user.role == Role.EMPLOYEE
+        assert manager.role == Role.MANAGER
+        assert user.team == manager.team
+        return user, manager
+
+    @pytest.fixture
+    def task(self, user_and_manager):
+        user, manager = user_and_manager
+        task = Task.create_task(title='Test task',
+                                assignee=user,
+                                created_by=manager,
+                                priority=Priority.LOW,
+                                status=Status.BACKLOG,
+                                description='This is a test task')
+        return task
+
+    @pytest.fixture
+    def comments(self, user_and_manager, task):
+            user, manager = user_and_manager
+            comments = {}
+            for i in range(1, NUM_COMMENTS + 1):
+                comments[f'comment{i}'] = Comment.objects.create(appUser=user,
+                                                                 task=task,
+                                                                 title=f'Comment{i}',
+                                                                 description='This is a test comment')
+            assert len(comments) == NUM_COMMENTS
+            return task
+    
+    def test_get_relevant_comments(self, task, comments):
+        fetched_comments = task.get_comments()
+        assert len(fetched_comments) == NUM_COMMENTS
+        assert isinstance(fetched_comments, QuerySet)
+        assert all(isinstance(comment, Comment) for comment in fetched_comments)
+        assert all(comment.appUser == task.assignee for comment in fetched_comments)
+
+    def test_comment_ordered_by_id_ascending(self, task, comments):
+        fetched_comments = task.get_comments()
+        for i in range(len(fetched_comments) - 1):
+            assert fetched_comments[i].id < fetched_comments[i+1].id

--- a/tasks/tests/test_get_task_comments.py
+++ b/tasks/tests/test_get_task_comments.py
@@ -5,6 +5,7 @@ from users.models import Role, User
 
 NUM_COMMENTS = 3
 
+
 @pytest.mark.django_db
 class TestTaskComments:
     @pytest.fixture
@@ -31,16 +32,16 @@ class TestTaskComments:
 
     @pytest.fixture
     def comments(self, user_and_manager, task):
-            user, manager = user_and_manager
-            comments = {}
-            for i in range(1, NUM_COMMENTS + 1):
-                comments[f'comment{i}'] = Comment.objects.create(appUser=user,
-                                                                 task=task,
-                                                                 title=f'Comment{i}',
-                                                                 description='This is a test comment')
-            assert len(comments) == NUM_COMMENTS
-            return task
-    
+        user, manager = user_and_manager
+        comments = {}
+        for i in range(1, NUM_COMMENTS + 1):
+            comments[f'comment{i}'] = Comment.objects.create(appUser=user,
+                                                             task=task,
+                                                             title=f'Comment{i}',
+                                                             description='This is a test comment')
+        assert len(comments) == NUM_COMMENTS
+        return task
+
     def test_get_relevant_comments(self, task, comments):
         fetched_comments = task.get_comments()
         assert len(fetched_comments) == NUM_COMMENTS


### PR DESCRIPTION
Fixes #125 
This PR adds the feature of displaying a task's comments at the bottom of the view single task template.

## Changes you made

- [x] Add get_comments method to Task model.
- [x] Add tests to the above method.
- [x] Add HTML to display each task's comments.
