### PR TITLE
Add redirection after a new task is created

### DIFF
--- a/tasks/tests/test_view_new_task.py
+++ b/tasks/tests/test_view_new_task.py
@@ -33,7 +33,7 @@ class TestViewNewTask:
         for task in valid_task_data:
             client.login(username=manager_1.user.username, password='password')
             response = client.post('/tasks/create', data=task)
-            assert response.status_code == 200
+            assert response.status_code == 302
             new_task = Task.objects.get(title=task['title'])
             assert new_task.title == task['title']
             assert new_task.assignee.user.id == task['assignee']

--- a/tasks/views.py
+++ b/tasks/views.py
@@ -39,9 +39,7 @@ def new_task(request):
                     try:
                         Task.create_task(task_form.title, task_form.assignee, task_form.created_by, task_form.priority,
                                          task_form.status, task_form.description)
-                        messages.success(request, 'Task was added successfully')
-                        color = 'green'
-                        form = TaskForm(request.user.id)
+                        return redirect('tasks')
                     except Exception as e:
                         messages.warning(request, e)
                         form = TaskForm(request.user.id, initial=initial_dict)


### PR DESCRIPTION
Fixes #151 
This PR adds a redirection from the task creation page to all tasks page, once a new task is created successfully.

## Changes you made

- Add redirection to 'view all tasks' template after a new task is created successfully.
- Updated the tests of valid task creation.
